### PR TITLE
Relationship view models

### DIFF
--- a/Application/Common/Interfaces/IRelationshipConvertor.cs
+++ b/Application/Common/Interfaces/IRelationshipConvertor.cs
@@ -1,0 +1,15 @@
+﻿using Sparkle.Application.Models;
+using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
+
+namespace Sparkle.Application.Common.Interfaces
+{
+    public interface IRelationshipConvertor
+    {
+        /// <summary>
+        /// Converts the specified relationship to a relationship view model.
+        /// </summary>
+        /// <param name="relationship">The relationship to convert.</param>
+        /// <returns>The relationship view model.</returns>
+        RelationshipViewModel Convert(Relationship relationship);
+    }
+}

--- a/Application/DependencyInjection.cs
+++ b/Application/DependencyInjection.cs
@@ -5,6 +5,7 @@ using Sparkle.Application.Common.Behaviors;
 using Sparkle.Application.Common.Factories;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Common.Mapping;
+using Sparkle.Application.Users.Relationships.Common;
 using System.Reflection;
 
 namespace Sparkle.Application
@@ -30,6 +31,8 @@ namespace Sparkle.Application
             });
 
             services.AddScoped<IRoleFactory, RoleFactory>();
+            services.AddScoped<IRelationshipConvertor, RelationshipConvertor>();
+
             return services;
         }
     }

--- a/Application/HubClients/Users/RelationshipDeleted/NotifyRelationshipDelatedQueryHandler.cs
+++ b/Application/HubClients/Users/RelationshipDeleted/NotifyRelationshipDelatedQueryHandler.cs
@@ -1,20 +1,26 @@
 ﻿using MediatR;
 using Sparkle.Application.Common.Interfaces;
+using Sparkle.Application.Models;
+using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
 
 namespace Sparkle.Application.HubClients.Users.RelationshipDeleted
 {
     public class NotifyRelationshipDelatedQueryHandler : HubRequestHandlerBase, IRequestHandler<NotifyRelationshipDelatedQuery>
     {
-        public NotifyRelationshipDelatedQueryHandler(IHubContextProvider hubContextProvider, IAppDbContext context)
+        private readonly IRelationshipConvertor _convertor;
+        public NotifyRelationshipDelatedQueryHandler(IHubContextProvider hubContextProvider, IAppDbContext context,
+            IRelationshipConvertor convertor)
             : base(hubContextProvider, context)
         {
+            _convertor = convertor;
         }
 
         public async Task Handle(NotifyRelationshipDelatedQuery query, CancellationToken cancellationToken)
         {
-            Models.Relationship relationship = query.Relationship;
+            Relationship relationship = query.Relationship;
+            RelationshipViewModel viewModel = _convertor.Convert(relationship);
 
-            await SendAsync(ClientMethods.RelationshipsDeleted, relationship,
+            await SendAsync(ClientMethods.RelationshipsDeleted, viewModel,
                 GetConnections(relationship.Passive, relationship.Passive));
         }
     }

--- a/Application/HubClients/Users/RelationshipUpdated/NotifyRelationshipUpdatedQueryHandler.cs
+++ b/Application/HubClients/Users/RelationshipUpdated/NotifyRelationshipUpdatedQueryHandler.cs
@@ -1,21 +1,26 @@
 ﻿using MediatR;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Models;
+using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
 
 namespace Sparkle.Application.HubClients.Users.RelationshipUpdated
 {
     public class NotifyRelationshipUpdatedQueryHandler : HubRequestHandlerBase, IRequestHandler<NotifyRelationshipUpdatedQuery>
     {
-        public NotifyRelationshipUpdatedQueryHandler(IHubContextProvider hubContextProvider, IAppDbContext context)
+        private readonly IRelationshipConvertor _convertor;
+        public NotifyRelationshipUpdatedQueryHandler(IHubContextProvider hubContextProvider, IAppDbContext context,
+            IRelationshipConvertor convertor)
             : base(hubContextProvider, context)
         {
+            _convertor = convertor;
         }
 
         public async Task Handle(NotifyRelationshipUpdatedQuery query, CancellationToken cancellationToken)
         {
             Relationship relationship = query.Relationship;
+            RelationshipViewModel viewModel = _convertor.Convert(relationship);
 
-            await SendAsync(ClientMethods.RelationshipsUpdated, relationship,
+            await SendAsync(ClientMethods.RelationshipsUpdated, viewModel,
                 GetConnections(relationship.Active, relationship.Passive));
         }
     }

--- a/Application/Models/Relationship.cs
+++ b/Application/Models/Relationship.cs
@@ -2,7 +2,6 @@
 {
     public enum RelationshipTypes
     {
-        Acquaintance,
         Friend,
         Pending,
         Blocked

--- a/Application/Users/Relationships/Commands/AcceptFriendRequest/AcceptFriendRequestCommand.cs
+++ b/Application/Users/Relationships/Commands/AcceptFriendRequest/AcceptFriendRequestCommand.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.AcceptFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.AcceptFriendRequest
 {
     public record AcceptFriendRequestCommand : IRequest<Relationship>
     {

--- a/Application/Users/Relationships/Commands/AcceptFriendRequest/AcceptFriendRequestCommandHandler.cs
+++ b/Application/Users/Relationships/Commands/AcceptFriendRequest/AcceptFriendRequestCommandHandler.cs
@@ -4,7 +4,7 @@ using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Common.Interfaces.Repositories;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.AcceptFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.AcceptFriendRequest
 {
     public class AcceptFriendRequestCommandHandler : RequestHandlerBase, IRequestHandler<AcceptFriendRequestCommand, Relationship>
     {

--- a/Application/Users/Relationships/Commands/AcceptFriendRequest/AcceptFriendRequestCommandValidator.cs
+++ b/Application/Users/Relationships/Commands/AcceptFriendRequest/AcceptFriendRequestCommandValidator.cs
@@ -1,6 +1,6 @@
 ﻿using FluentValidation;
 
-namespace Sparkle.Application.Users.Relationships.AcceptFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.AcceptFriendRequest
 {
     public class AcceptFriendRequestCommandValidator : AbstractValidator<AcceptFriendRequestCommand>
     {

--- a/Application/Users/Relationships/Commands/CancelFriendRequest/CancelFriendRequestCommand.cs
+++ b/Application/Users/Relationships/Commands/CancelFriendRequest/CancelFriendRequestCommand.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.CancelFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.CancelFriendRequest
 {
     public record CancelFriendRequestCommand : IRequest<Relationship>
     {

--- a/Application/Users/Relationships/Commands/CancelFriendRequest/CancelFriendRequestCommandHandler.cs
+++ b/Application/Users/Relationships/Commands/CancelFriendRequest/CancelFriendRequestCommandHandler.cs
@@ -3,7 +3,7 @@ using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Common.Interfaces.Repositories;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.CancelFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.CancelFriendRequest
 {
     public class CancelFriendRequestCommandHandler : RequestHandlerBase, IRequestHandler<CancelFriendRequestCommand, Relationship>
     {

--- a/Application/Users/Relationships/Commands/DeleteFriend/DeleteFriendCommand.cs
+++ b/Application/Users/Relationships/Commands/DeleteFriend/DeleteFriendCommand.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.DeleteFriend
+namespace Sparkle.Application.Users.Relationships.Commands.DeleteFriend
 {
     public record DeleteFriendCommand : IRequest<Relationship>
     {

--- a/Application/Users/Relationships/Commands/DeleteFriend/DeleteFriendCommandHandler.cs
+++ b/Application/Users/Relationships/Commands/DeleteFriend/DeleteFriendCommandHandler.cs
@@ -3,7 +3,7 @@ using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Common.Interfaces.Repositories;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.DeleteFriend
+namespace Sparkle.Application.Users.Relationships.Commands.DeleteFriend
 {
     public class DeleteFriendCommandHandler : RequestHandlerBase, IRequestHandler<DeleteFriendCommand, Relationship>
     {

--- a/Application/Users/Relationships/Commands/SendFriendRequest/CreateFriendRequestCommand.cs
+++ b/Application/Users/Relationships/Commands/SendFriendRequest/CreateFriendRequestCommand.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.SendFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.SendFriendRequest
 {
     public record CreateFriendRequestCommand : IRequest<Relationship>
     {

--- a/Application/Users/Relationships/Commands/SendFriendRequest/CreateFriendRequestCommandHandler.cs
+++ b/Application/Users/Relationships/Commands/SendFriendRequest/CreateFriendRequestCommandHandler.cs
@@ -3,7 +3,7 @@ using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Common.Interfaces.Repositories;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Relationships.SendFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.SendFriendRequest
 {
     public class CreateFriendRequestCommandHandler : RequestHandlerBase, IRequestHandler<CreateFriendRequestCommand, Relationship>
     {

--- a/Application/Users/Relationships/Commands/SendFriendRequest/CreateFriendRequestCommandValidator.cs
+++ b/Application/Users/Relationships/Commands/SendFriendRequest/CreateFriendRequestCommandValidator.cs
@@ -1,6 +1,6 @@
 ﻿using FluentValidation;
 
-namespace Sparkle.Application.Users.Relationships.SendFriendRequest
+namespace Sparkle.Application.Users.Relationships.Commands.SendFriendRequest
 {
     public class CreateFriendRequestCommandValidator : AbstractValidator<CreateFriendRequestCommand>
     {

--- a/Application/Users/Relationships/Common/RelationshipConvertor.cs
+++ b/Application/Users/Relationships/Common/RelationshipConvertor.cs
@@ -1,0 +1,40 @@
+﻿using AutoMapper;
+using Sparkle.Application.Common.Interfaces;
+using Sparkle.Application.Models;
+using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
+
+namespace Sparkle.Application.Users.Relationships.Common
+{
+    public class RelationshipConvertor : IRelationshipConvertor
+    {
+        private readonly IRepository<User, Guid> _userRepository;
+        private readonly IAuthorizedUserProvider _userProvider;
+        private readonly IMapper _mapper;
+
+        public RelationshipConvertor(IRepository<User, Guid> userRepository,
+            IAuthorizedUserProvider userProvider,
+            IMapper mapper)
+        {
+            _userRepository = userRepository;
+            _userProvider = userProvider;
+            _mapper = mapper;
+        }
+
+        public RelationshipViewModel Convert(Relationship relationship)
+        {
+            Guid userId = _userProvider.GetUserId();
+
+            User? user = _userRepository
+                 .FindAsync(relationship.Active == userId
+                 ? relationship.Passive : relationship.Active)
+                 .Result;
+
+            return new RelationshipViewModel
+            {
+                IsActive = relationship.Active != userId,
+                User = _mapper.Map<UserLookupViewModel>(user),
+                Type = relationship.RelationshipType
+            };
+        }
+    }
+}

--- a/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQuery.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQuery.cs
@@ -1,5 +1,4 @@
 ﻿using MediatR;
-using Sparkle.Contracts.Users.Relationships;
 
 namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
 {

--- a/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQuery.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQuery.cs
@@ -1,8 +1,8 @@
 ﻿using MediatR;
-using Sparkle.Application.Models;
+using Sparkle.Contracts.Users.Relationships;
 
 namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
 {
     public record GetRelationshipQuery()
-        : IRequest<List<Relationship>>;
+        : IRequest<List<RelationshipViewModel>>;
 }

--- a/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQuery.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQuery.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Queries.GetRelationships
+namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
 {
     public record GetRelationshipQuery()
         : IRequest<List<Relationship>>;

--- a/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQueryHandler.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQueryHandler.cs
@@ -2,22 +2,39 @@
 using Microsoft.EntityFrameworkCore;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Models;
+using Sparkle.Contracts.Users.Relationships;
 
 namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
 {
     public class GetRelationshipQueryHandler : RequestHandlerBase,
-        IRequestHandler<GetRelationshipQuery, List<Relationship>>
+        IRequestHandler<GetRelationshipQuery, List<RelationshipViewModel>>
     {
         public GetRelationshipQueryHandler(IAppDbContext context, IAuthorizedUserProvider userProvider)
             : base(context, userProvider)
         {
         }
 
-        public async Task<List<Relationship>> Handle(GetRelationshipQuery query, CancellationToken cancellationToken)
+        public async Task<List<RelationshipViewModel>> Handle(GetRelationshipQuery query, CancellationToken cancellationToken)
         {
-            return await Context.Relationships
+            List<Relationship> relationships = await Context.Relationships
                 .Where(rel => rel.Active == UserId || rel.Passive == UserId)
                 .ToListAsync(cancellationToken);
+
+            return relationships.ConvertAll(ToViewModel);
+        }
+
+        private RelationshipViewModel ToViewModel(Relationship relationship)
+        {
+            User? user = Context.Users
+                .Find(relationship.Active == UserId
+                ? relationship.Passive : relationship.Active);
+
+            return new RelationshipViewModel
+            {
+                IsActive = relationship.Active != UserId,
+                User = Mapper.Map<UserLookupViewModel>(user),
+                Type = relationship.RelationshipType
+            };
         }
     }
 }

--- a/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQueryHandler.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/GetRelationshipQueryHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Models;
 
-namespace Sparkle.Application.Users.Queries.GetRelationships
+namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
 {
     public class GetRelationshipQueryHandler : RequestHandlerBase,
         IRequestHandler<GetRelationshipQuery, List<Relationship>>

--- a/Application/Users/Relationships/Queries/GetRelationships/RelationshipViewModel.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/RelationshipViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Sparkle.Application.Models;
-using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
 
-namespace Sparkle.Contracts.Users.Relationships
+namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
 {
     /// <summary>
     /// Represents a relationship view model.

--- a/Application/Users/Relationships/Queries/GetRelationships/RelationshipViewModel.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/RelationshipViewModel.cs
@@ -1,0 +1,28 @@
+﻿using Sparkle.Application.Models;
+using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
+
+namespace Sparkle.Contracts.Users.Relationships
+{
+    /// <summary>
+    /// Represents a relationship view model.
+    /// </summary>
+    public record RelationshipViewModel
+    {
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the relationship is active.
+        /// </summary>
+        /// <remarks>If <see langword="true"/>: current user is passive user</remarks>
+        public bool IsActive { get; init; }
+
+        /// <summary>
+        /// Gets or sets the user lookup view model.
+        /// </summary>
+        public UserLookupViewModel User { get; init; }
+
+        /// <summary>
+        /// Gets or sets the relationship type.
+        /// </summary>
+        public RelationshipTypes Type { get; init; }
+    }
+}

--- a/Application/Users/Relationships/Queries/GetRelationships/UserLookupViewModel.cs
+++ b/Application/Users/Relationships/Queries/GetRelationships/UserLookupViewModel.cs
@@ -1,0 +1,44 @@
+﻿using AutoMapper;
+using Sparkle.Application.Common.Interfaces;
+using Sparkle.Application.Models;
+
+namespace Sparkle.Application.Users.Relationships.Queries.GetRelationships
+{
+
+    public record UserLookupViewModel : IMapWith<User>
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the user.
+        /// </summary>
+        public Guid Id { get; init; }
+
+        /// <summary>
+        /// Gets or sets the unique username of the user.
+        /// </summary>
+        public string Username { get; init; }
+
+        /// <summary>
+        /// Gets or sets the display name of the user.
+        /// </summary>
+        public string? DisplayName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the avatar URL of the user.
+        /// </summary>
+        public string? AvatarUrl { get; init; }
+
+        /// <summary>
+        /// Gets or sets the status of the user.
+        /// </summary>
+        public UserStatus Status { get; init; }
+
+        /// <summary>
+        /// Configures the mapping between the User and UserLookupViewModel types.
+        /// </summary>
+        /// <param name="profile">The AutoMapper profile.</param>
+        public void Mapping(Profile profile)
+        {
+            profile.CreateMap<User, UserLookupViewModel>();
+        }
+    }
+}

--- a/Contracts/Contracts.csproj
+++ b/Contracts/Contracts.csproj
@@ -14,4 +14,9 @@
     <ProjectReference Include="..\Application\Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Users\" />
+    <Folder Include="Users\Relationships\" />
+  </ItemGroup>
+
 </Project>

--- a/DataAccess/Migrations/20230930131248_AddInitialRelationships.cs
+++ b/DataAccess/Migrations/20230930131248_AddInitialRelationships.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -28,9 +27,9 @@ namespace DataAccess.Migrations
                 columns: new[] { "Active", "Passive", "RelationshipType" },
                 values: new object[,]
                 {
-                    { new Guid("7aef2538-e1b3-42d7-a3db-a2809a81ac91"), new Guid("ba1ce081-e200-41da-9fb2-3d317627c9d4"), 2 },
-                    { new Guid("c1ce2c28-9cf4-4ab1-bddb-b99c5408ee34"), new Guid("7aef2538-e1b3-42d7-a3db-a2809a81ac91"), 1 },
-                    { new Guid("c1ce2c28-9cf4-4ab1-bddb-b99c5408ee34"), new Guid("ba1ce081-e200-41da-9fb2-3d317627c9d4"), 1 }
+                    { new Guid("7aef2538-e1b3-42d7-a3db-a2809a81ac91"), new Guid("ba1ce081-e200-41da-9fb2-3d317627c9d4"), 1 },
+                    { new Guid("c1ce2c28-9cf4-4ab1-bddb-b99c5408ee34"), new Guid("7aef2538-e1b3-42d7-a3db-a2809a81ac91"), 0 },
+                    { new Guid("c1ce2c28-9cf4-4ab1-bddb-b99c5408ee34"), new Guid("ba1ce081-e200-41da-9fb2-3d317627c9d4"), 0 }
                 });
         }
 

--- a/DataAccess/Queries/GetUserRelationships.sql
+++ b/DataAccess/Queries/GetUserRelationships.sql
@@ -6,10 +6,9 @@ SELECT
     U2.UserName AS PassiveName,
     U2.Id AS PassiveId,
     CASE
-        WHEN R.RelationshipType = 0 THEN 'Acquaintance'
-        WHEN R.RelationshipType = 1 THEN 'Friend'
-        WHEN R.RelationshipType = 2 THEN 'Pending'
-        WHEN R.RelationshipType = 3 THEN 'Blocked'
+        WHEN R.RelationshipType = 0 THEN 'Friend'
+        WHEN R.RelationshipType = 1 THEN 'Pending'
+        WHEN R.RelationshipType = 2 THEN 'Blocked'
     END AS RelationshipType
 FROM
     Relationships R

--- a/WebApi/Controllers/UsersController.cs
+++ b/WebApi/Controllers/UsersController.cs
@@ -7,13 +7,13 @@ using Sparkle.Application.HubClients.Users.UserUpdated;
 using Sparkle.Application.Models;
 using Sparkle.Application.Users.Commands.ChangeDisplayName;
 using Sparkle.Application.Users.Commands.SendMessageToUser;
-using Sparkle.Application.Users.Queries.GetRelationships;
 using Sparkle.Application.Users.Queries.GetUserByUserName;
 using Sparkle.Application.Users.Queries.GetUserDetails;
-using Sparkle.Application.Users.Relationships.AcceptFriendRequest;
-using Sparkle.Application.Users.Relationships.CancelFriendRequest;
-using Sparkle.Application.Users.Relationships.DeleteFriend;
-using Sparkle.Application.Users.Relationships.SendFriendRequest;
+using Sparkle.Application.Users.Relationships.Commands.AcceptFriendRequest;
+using Sparkle.Application.Users.Relationships.Commands.CancelFriendRequest;
+using Sparkle.Application.Users.Relationships.Commands.DeleteFriend;
+using Sparkle.Application.Users.Relationships.Commands.SendFriendRequest;
+using Sparkle.Application.Users.Relationships.Queries.GetRelationships;
 
 namespace Sparkle.WebApi.Controllers
 {


### PR DESCRIPTION
Added `RelationshipViewModel` which will be returned in `Relationship` notifications or queries (closes #109)
```json
   {
        "isActive": false,
        "user": {
            "id": "ba1ce081-e200-41da-9fb2-3d317627c9d4",
            "username": "dnesh3",
            "displayName": "Grabbot",
            "avatarUrl": null,
            "status": 3
        },
        "type": 1
    }
  ```
**Important:** `isActive` is true if the current user is **not** the active user.
  
### Changes Made: 

-  Removed `Acquaintance` relationship type  due to redundancy
- - Added `RelationshipViewModel` to provide a more informative response in `Relationship` notifications and queries
- Add `IRelationshipConvertor` service to convert `Relationship` to `RelationshipViewModel`