### PR TITLE
Private chat lookup

### DIFF
--- a/Application/HubClients/PrivateChats/PrivateChatSaved/NotifyPrivateChatSavedRequestHandler.cs
+++ b/Application/HubClients/PrivateChats/PrivateChatSaved/NotifyPrivateChatSavedRequestHandler.cs
@@ -46,7 +46,7 @@ namespace Sparkle.Application.HubClients.PrivateChats.PrivateChatSaved
             switch (chat)
             {
                 case GroupChat gChat:
-                    lookUp = Mapper.Map<PrivateChatLookUp>(gChat);
+                    lookUp = Mapper.Map<GroupChatLookup>(gChat);
                     break;
                 case PersonalChat pChat:
                     User other = await Context.Users
@@ -54,7 +54,7 @@ namespace Sparkle.Application.HubClients.PrivateChats.PrivateChatSaved
                         .Any(profile => profile.ChatId == chat.Id && user.Id != UserId),
                         cancellationToken: cancellationToken);
 
-                    lookUp = new PrivateChatLookUp(pChat, other);
+                    lookUp = Mapper.Map<PersonalChatLookup>((other, pChat));
                     break;
                 default:
                     throw new ArgumentException("the given chat is not an private chat");

--- a/Application/Models/User.cs
+++ b/Application/Models/User.cs
@@ -29,7 +29,7 @@ namespace Sparkle.Application.Models
         /// Unique username for the user.
         /// </summary>
         [DefaultValue("username")]
-        public new string UserName { get; set; }
+        public override string UserName { get; set; }
 
         /// <summary>
         /// Non-unique display name shown to other users.

--- a/Identity/RequestHandlers/LoginRequestHandler.cs
+++ b/Identity/RequestHandlers/LoginRequestHandler.cs
@@ -23,7 +23,7 @@ namespace Sparkle.Identity.RequestHandlers
             string userName = user?.UserName ?? string.Empty;
 
             return await _signInManager
-                .PasswordSignInAsync(userName, request.Password, request.RememberMe, true);
+                .PasswordSignInAsync(userName, request.Password, true, true);
         }
     }
 }

--- a/WebApi/Common/Convertors/PrivateChatJsonConvertor.cs
+++ b/WebApi/Common/Convertors/PrivateChatJsonConvertor.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Sparkle.Application.Models.LookUps;
+
+namespace Sparkle.Application.Common.Convertors
+{
+    public class PrivateChatLookUpConverter : JsonConverter<PrivateChatLookUp>
+    {
+        public override PrivateChatLookUp? ReadJson(JsonReader reader, Type objectType, PrivateChatLookUp? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+
+            if (jObject["membersCount"] != null)
+            {
+                return jObject.ToObject<GroupChatLookup>(serializer);
+            }
+            else
+            {
+                return jObject.ToObject<PersonalChatLookup>(serializer);
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, PrivateChatLookUp? value, JsonSerializer serializer)
+        {
+            JObject jObject;
+            switch (value)
+            {
+                case GroupChatLookup groupChat:
+                    jObject = JObject.FromObject(groupChat, serializer);
+                    jObject.WriteTo(writer);
+                    break;
+
+                case PersonalChatLookup personalChat:
+                    jObject = JObject.FromObject(personalChat, serializer);
+                    jObject.WriteTo(writer);
+                    break;
+
+                default:
+                    throw new ArgumentException("the given value is not a private chat look up");
+            }
+
+        }
+    }
+}

--- a/WebApi/Controllers/PrivateChatsContoller.cs
+++ b/WebApi/Controllers/PrivateChatsContoller.cs
@@ -1,6 +1,7 @@
 using MapsterMapper;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using Sparkle.Application.Chats.GroupChats.Commands.AddMemberToGroupChat;
 using Sparkle.Application.Chats.GroupChats.Commands.ChangeGroupChatImage;
 using Sparkle.Application.Chats.GroupChats.Commands.ChangeGroupChatOwner;
@@ -11,6 +12,7 @@ using Sparkle.Application.Chats.PersonalChats.Commands.CreateChat;
 using Sparkle.Application.Chats.PersonalChats.Queries;
 using Sparkle.Application.Chats.Queries.PrivateChatDetails;
 using Sparkle.Application.Chats.Queries.PrivateChatsList;
+using Sparkle.Application.Common.Convertors;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.HubClients.PrivateChats.PrivateChatSaved;
 using Sparkle.Application.Models;
@@ -20,6 +22,7 @@ using Sparkle.Contracts.PrivateChats;
 namespace Sparkle.WebApi.Controllers
 {
     [Route("api/private-chats")]
+    [JsonConverter(typeof(PrivateChatLookUpConverter))]
     public class PrivateChatsController : ApiControllerBase
     {
         public PrivateChatsController(IMediator mediator, IAuthorizedUserProvider userProvider, IMapper mapper)
@@ -36,7 +39,8 @@ namespace Sparkle.WebApi.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<ActionResult<List<PrivateChatLookUp>>> GetAllPrivateChats()
+
+        public async Task<ActionResult> GetAllPrivateChats()
         {
             PrivateChatsQuery query = new();
             List<PrivateChatLookUp> list = await Mediator.Send(query);

--- a/WebApi/DependencyInjection.cs
+++ b/WebApi/DependencyInjection.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
+using Sparkle.Application.Common.Convertors;
 using Sparkle.WebApi.Attributes;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -11,6 +12,9 @@ namespace Sparkle.WebApi
             services.AddControllers(options =>
             {
                 options.Filters.Add<ExceptionFilterAttribute>();
+            }).AddNewtonsoftJson(options =>
+            {
+                options.SerializerSettings.Converters.Add(new PrivateChatLookUpConverter());
             });
 
             services.AddSwagger();

--- a/WebApi/DependencyInjection.cs
+++ b/WebApi/DependencyInjection.cs
@@ -12,9 +12,9 @@ namespace Sparkle.WebApi
             services.AddControllers(options =>
             {
                 options.Filters.Add<ExceptionFilterAttribute>();
-            }).AddNewtonsoftJson(options =>
+            }).AddJsonOptions(options =>
             {
-                options.SerializerSettings.Converters.Add(new PrivateChatLookUpConverter());
+                options.JsonSerializerOptions.Converters.Add(new PrivateChatLookUpConverter());
             });
 
             services.AddSwagger();

--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
 using Sparkle.Application;
+using Sparkle.Application.Common.Convertors;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.DataAccess;
 using Sparkle.WebApi;
@@ -25,6 +26,9 @@ services.AddApplication();
 services.AddControllers(options =>
 {
     options.Filters.Add<ExceptionFilterAttribute>();
+}).AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new PrivateChatLookUpConverter());
 });
 
 services.AddDatabase(builder.Configuration);


### PR DESCRIPTION
# Description
The lookups for `PersonalChat` and `GroupChat` modified to provide different information based on the chat type.

### Personal Chat

```json
  {
        "userStatus": 3,
        "usersTextStatus": null,
        "id": "651ff1b9d4776fb2bd46a252",
        "title": "dnesh2",
        "image": null,
        "updatedDate": "2023-10-06T11:38:33.032Z"
    }
```
- Added `userStatus` and `userTextStatus` fields (Closes #116)
- Removed `membersCount` field

### Group Chat
```json
{
        "membersCount": 3,
        "id": "651ff1afd4776fb2bd46a24f",
        "title": "Grabbot, dnesh2",
        "image": null,
        "updatedDate": "2023-10-06T11:42:31.45Z"
    }
```
- Resembles the old `PrivateChatLookup`
- Includes the `membersCount` field

# Changes Made
- For `PersonalChat`, introduced new fields `userStatus` and `userTextStatus` to provide specific user-related information.
- Removed the `membersCount` field for `PersonalChat` lookups.
- For `GroupChat`, kept the structure similar to the old `PrivateChatLookup` and retained the `membersCount` field.

These changes ensure that clients receive appropriate and distinct information depending on whether the chat is a `PersonalChat` or a `GroupChat`. This enhances the overall usability and clarity of our chat lookups.
