### PR TITLE
Server factory

### DIFF
--- a/Application/Common/Constants/Constants.Channel.cs
+++ b/Application/Common/Constants/Constants.Channel.cs
@@ -4,7 +4,10 @@
     {
         public static class Channel
         {
+#pragma warning disable IDE1006 // Naming Styles
             public const int TitleMaxLength = 100;
+            public const string WelcomeChannelName = "welcome";
+#pragma warning restore IDE1006 // Naming Styles
         }
     }
 }

--- a/Application/Common/Constants/Constants.Channel.cs
+++ b/Application/Common/Constants/Constants.Channel.cs
@@ -6,7 +6,7 @@
         {
 #pragma warning disable IDE1006 // Naming Styles
             public const int TitleMaxLength = 100;
-            public const string WelcomeChannelName = "welcome";
+            public const string WelcomeChannelTitle = "welcome";
 #pragma warning restore IDE1006 // Naming Styles
         }
     }

--- a/Application/Common/Factories/RoleFactory.cs
+++ b/Application/Common/Factories/RoleFactory.cs
@@ -74,45 +74,45 @@ namespace Sparkle.Application.Common.Factories
 
         private readonly Role _groupChatOwnerRole = new()
         {
-            Id = Constants.Constants.Roles.GroupChatOwnerId,
-            Name = Constants.Constants.Roles.GroupChatOwnerName,
-            Color = Constants.Constants.Roles.DefaultColor,
+            Id = Roles.GroupChatOwnerId,
+            Name = Roles.GroupChatOwnerName,
+            Color = Roles.DefaultColor,
             ServerId = null,
             Priority = 1,
         };
 
         private readonly Role _groupChatMemberRole = new()
         {
-            Id = Constants.Constants.Roles.GroupChatMemberId,
-            Name = Constants.Constants.Roles.GroupChatMemberName,
-            Color = Constants.Constants.Roles.DefaultColor,
+            Id = Roles.GroupChatMemberId,
+            Name = Roles.GroupChatMemberName,
+            Color = Roles.DefaultColor,
             ServerId = null,
             Priority = 0,
         };
 
         private readonly Role _personalChatMemberRole = new()
         {
-            Id = Constants.Constants.Roles.PrivateChatMemberId,
-            Name = Constants.Constants.Roles.PrivateChatMemberName,
-            Color = Constants.Constants.Roles.DefaultColor,
+            Id = Roles.PrivateChatMemberId,
+            Name = Roles.PrivateChatMemberName,
+            Color = Roles.DefaultColor,
             ServerId = null,
             Priority = 0,
         };
 
         private readonly Role _serverOwnerRole = new()
         {
-            Id = Constants.Constants.Roles.ServerOwnerId,
-            Name = Constants.Constants.Roles.ServerOwnerName,
-            Color = Constants.Constants.Roles.DefaultColor,
+            Id = Roles.ServerOwnerId,
+            Name = Roles.ServerOwnerName,
+            Color = Roles.DefaultColor,
             ServerId = null,
             Priority = 100,
         };
 
         private readonly Role _serverMemberRole = new()
         {
-            Id = Constants.Constants.Roles.ServerMemberId,
-            Name = Constants.Constants.Roles.ServerMemberName,
-            Color = Constants.Constants.Roles.DefaultColor,
+            Id = Roles.ServerMemberId,
+            Name = Roles.ServerMemberName,
+            Color = Roles.DefaultColor,
             ServerId = null,
             Priority = 0,
         };

--- a/Application/Common/Factories/ServerFactory.cs
+++ b/Application/Common/Factories/ServerFactory.cs
@@ -98,5 +98,39 @@ namespace Sparkle.Application.Common.Factories
 
             return (server, owner, channels);
         }
+        public (Server Server, ServerProfile Owner, List<Channel> Channels) SchoolServer(string title, string? image)
+        {
+            (Server server, ServerProfile owner, List<Channel> channels) = DefaultServer(title, image);
+
+            Channel CreateFunc(string title) => CreateChannel(server, owner, title);
+
+            List<Channel> newChannels = new()
+            {
+                CreateFunc("common"),
+                CreateFunc("notification"),
+                CreateFunc("resources"),
+                CreateFunc("meetings"),
+                CreateFunc("offtopic")
+            };
+            channels.AddRange(newChannels);
+
+            return (server, owner, channels);
+        }
+        public (Server Server, ServerProfile Owner, List<Channel> Channels) FriendsServer(string title, string? image)
+        {
+            (Server server, ServerProfile owner, List<Channel> channels) = DefaultServer(title, image);
+
+            Channel CreateFunc(string title) => CreateChannel(server, owner, title);
+
+            List<Channel> newChannels = new()
+            {
+                CreateFunc("common"),
+                CreateFunc("games"),
+                CreateFunc("music"),
+            };
+            channels.AddRange(newChannels);
+
+            return (server, owner, channels);
+        }
     }
 }

--- a/Application/Common/Factories/ServerFactory.cs
+++ b/Application/Common/Factories/ServerFactory.cs
@@ -39,20 +39,70 @@ namespace Sparkle.Application.Common.Factories
             return (server, owner);
         }
 
-        public (Server Server, ServerProfile Owner, Channel Channel) DefaultServer(string title, string? image)
+        public (Server Server, ServerProfile Owner, List<Channel> Channels) DefaultServer(string title, string? image)
         {
             (Server server, ServerProfile owner) = BaseServer(title, image);
 
-            Channel welcomeChannel = new()
+            Channel welcomeChannel = CreateChannel(server, owner, Constants.Constants.Channel.WelcomeChannelTitle);
+            List<Channel> channels = new() { welcomeChannel };
+
+            return (server, owner, channels);
+        }
+
+        private static Channel CreateChannel(Server server, ServerProfile owner, string title)
+        {
+            return new()
             {
                 CreatedDate = DateTime.Now,
                 UpdatedDate = DateTime.Now,
                 ServerId = server.Id,
                 Profiles = { owner.Id },
-                Title = Constants.Constants.Channel.WelcomeChannelName
+                Title = title
             };
-
-            return (server, owner, welcomeChannel);
         }
+
+        public (Server Server, ServerProfile Owner, List<Channel> Channels) GamingServer(string title, string? image)
+        {
+            (Server server, ServerProfile owner, List<Channel> channels) = DefaultServer(title, image);
+
+            Channel CreateFunc(string title) => CreateChannel(server, owner, title);
+
+            Channel common = CreateFunc("common");
+            Channel lobby = CreateFunc("lobby");
+            Channel games = CreateFunc("game");
+            Channel bestMoments = CreateFunc("best-moments");
+
+            List<Channel> newChannels = new()
+            {
+                common, lobby, games, bestMoments
+            };
+            channels.AddRange(newChannels);
+
+            return (server, owner, channels);
+        }
+
+        public (Server Server, ServerProfile Owner, List<Channel> Channels) StudyServer(string title, string? image)
+        {
+            (Server server, ServerProfile owner, List<Channel> channels) = DefaultServer(title, image);
+
+            Channel CreateFunc(string title) => CreateChannel(server, owner, title);
+
+            Channel common = CreateFunc("common");
+            Channel homework = CreateFunc("help-with-homework");
+
+            List<Channel> newChannels = new()
+            {
+                common, homework
+            };
+            channels.AddRange(newChannels);
+
+            return (server, owner, channels);
+        }
+    }
+    public enum ServerType
+    {
+        Default,
+        Gaming,
+        Study
     }
 }

--- a/Application/Common/Factories/ServerFactory.cs
+++ b/Application/Common/Factories/ServerFactory.cs
@@ -99,10 +99,4 @@ namespace Sparkle.Application.Common.Factories
             return (server, owner, channels);
         }
     }
-    public enum ServerType
-    {
-        Default,
-        Gaming,
-        Study
-    }
 }

--- a/Application/Common/Factories/ServerFactory.cs
+++ b/Application/Common/Factories/ServerFactory.cs
@@ -1,0 +1,58 @@
+﻿using Sparkle.Application.Common.Interfaces;
+using Sparkle.Application.Models;
+
+namespace Sparkle.Application.Common.Factories
+{
+
+    public class ServerFactory
+    {
+        private readonly IRoleFactory _roleFactory;
+
+        private readonly IAuthorizedUserProvider _userProvider;
+        public ServerFactory(IRoleFactory roleFactory, IAuthorizedUserProvider userProvider)
+        {
+            _roleFactory = roleFactory;
+            _userProvider = userProvider;
+        }
+
+        private (Server Server, ServerProfile Owner) BaseServer(string title, string? image)
+        {
+            List<Role> roles = _roleFactory.GetDefaultServerRoles();
+            (Role ownerRole, Role memberRole) = (roles[0], roles[1]);
+
+            Server server = new()
+            {
+                Title = title,
+                Image = image,
+                Roles = roles.ConvertAll(role => role.Id),
+            };
+
+            ServerProfile owner = new()
+            {
+                UserId = _userProvider.GetUserId(),
+                ServerId = server.Id,
+                Roles = { ownerRole }
+            };
+
+            server.Profiles.Add(owner.Id);
+
+            return (server, owner);
+        }
+
+        public (Server Server, ServerProfile Owner, Channel Channel) DefaultServer(string title, string? image)
+        {
+            (Server server, ServerProfile owner) = BaseServer(title, image);
+
+            Channel welcomeChannel = new()
+            {
+                CreatedDate = DateTime.Now,
+                UpdatedDate = DateTime.Now,
+                ServerId = server.Id,
+                Profiles = { owner.Id },
+                Title = Constants.Constants.Channel.WelcomeChannelName
+            };
+
+            return (server, owner, welcomeChannel);
+        }
+    }
+}

--- a/Application/DependencyInjection.cs
+++ b/Application/DependencyInjection.cs
@@ -36,6 +36,8 @@ namespace Sparkle.Application
             services.AddScoped<IRoleFactory, RoleFactory>();
             services.AddScoped<IConvertor, Convertor>();
 
+            services.AddScoped<ServerFactory>();
+
             return services;
         }
     }

--- a/Application/DependencyInjection.cs
+++ b/Application/DependencyInjection.cs
@@ -33,9 +33,9 @@ namespace Sparkle.Application
                 config.AddProfile(new AssemblyMappingProfile(typeof(IAppDbContext).Assembly));
             });
 
-            services.AddScoped<IRoleFactory, RoleFactory>();
             services.AddScoped<IConvertor, Convertor>();
 
+            services.AddScoped<IRoleFactory, RoleFactory>();
             services.AddScoped<ServerFactory>();
 
             return services;

--- a/Application/Servers/Commands/CreateServer/CreateServerCommand.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommand.cs
@@ -25,6 +25,8 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
     {
         Default,
         Gaming,
-        Study
+        Study,
+        School,
+        Friends
     }
 }

--- a/Application/Servers/Commands/CreateServer/CreateServerCommand.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommand.cs
@@ -1,5 +1,4 @@
 ﻿using MediatR;
-using Sparkle.Application.Common.Factories;
 using Sparkle.Application.Models;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -19,6 +18,13 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
         [DataType(DataType.ImageUrl)]
         [DefaultValue("https://localhost:7060/api/media/5f95a3c3d0ddad0017ea9291")]
         public string? Image { get; init; }
-        public ServerType? Template { get; init; } = ServerType.Default;
+        public ServerTemplates? Template { get; init; } = ServerTemplates.Default;
+    }
+
+    public enum ServerTemplates
+    {
+        Default,
+        Gaming,
+        Study
     }
 }

--- a/Application/Servers/Commands/CreateServer/CreateServerCommand.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Sparkle.Application.Common.Factories;
 using Sparkle.Application.Models;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -18,5 +19,6 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
         [DataType(DataType.ImageUrl)]
         [DefaultValue("https://localhost:7060/api/media/5f95a3c3d0ddad0017ea9291")]
         public string? Image { get; init; }
+        public ServerType? Template { get; init; } = ServerType.Default;
     }
 }

--- a/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using Sparkle.Application.Common.Constants;
+using Sparkle.Application.Common.Factories;
 using Sparkle.Application.Common.Interfaces;
 using Sparkle.Application.Common.Interfaces.Repositories;
 using Sparkle.Application.Models;
@@ -8,42 +8,29 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
 {
     public class CreateServerCommandHandler : RequestHandlerBase, IRequestHandler<CreateServerCommand, Server>
     {
-        private readonly IRoleFactory _roleFactory;
+        private readonly ServerFactory _serverFactory;
         private readonly IServerProfileRepository _serverProfileRepository;
         public async Task<Server> Handle(CreateServerCommand command, CancellationToken cancellationToken)
         {
             Context.SetToken(cancellationToken);
 
-            Server server = new()
-            {
-                Title = command.Title,
-                Image = command.Image,
-            };
-
-            List<Role> roles = _roleFactory.GetDefaultServerRoles();
-
-            Role ownerRole = roles.First(role => role.Name == Constants.Roles.ServerOwnerName);
-
-            ServerProfile owner = new()
-            {
-                UserId = UserId,
-                ServerId = server.Id,
-                Roles = { ownerRole }
-            };
-
-            server.Roles.AddRange(roles.ConvertAll(role => role.Id));
-            server.Profiles.Add(owner.Id);
+            (Server server, ServerProfile owner, Channel welcomeChannel) =
+                _serverFactory.DefaultServer(command.Title, command.Image);
 
             await _serverProfileRepository.AddAsync(owner, cancellationToken);
             await Context.Servers.AddAsync(server, cancellationToken);
+            await Context.Channels.AddAsync(welcomeChannel, cancellationToken);
 
             return server;
         }
 
-        public CreateServerCommandHandler(IAppDbContext context, IAuthorizedUserProvider userProvider, IRoleFactory roleFactory, IServerProfileRepository serverProfileRepository)
+        public CreateServerCommandHandler(IAppDbContext context,
+            IAuthorizedUserProvider userProvider,
+            ServerFactory serverFactory,
+            IServerProfileRepository serverProfileRepository)
             : base(context, userProvider)
         {
-            _roleFactory = roleFactory;
+            _serverFactory = serverFactory;
             _serverProfileRepository = serverProfileRepository;
         }
     }

--- a/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
@@ -21,6 +21,8 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
                 {
                     ServerTemplates.Study => _serverFactory.StudyServer(command.Title, command.Image),
                     ServerTemplates.Gaming => _serverFactory.GamingServer(command.Title, command.Image),
+                    ServerTemplates.School => _serverFactory.SchoolServer(command.Title, command.Image),
+                    ServerTemplates.Friends => _serverFactory.FriendsServer(command.Title, command.Image),
                     ServerTemplates.Default or _ => _serverFactory.DefaultServer(command.Title, command.Image)
                 };
 

--- a/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
@@ -14,12 +14,19 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
         {
             Context.SetToken(cancellationToken);
 
-            (Server server, ServerProfile owner, Channel welcomeChannel) =
-                _serverFactory.DefaultServer(command.Title, command.Image);
+            ServerType template = command.Template ?? ServerType.Default;
+
+            (Server server, ServerProfile owner, List<Channel> channels) =
+                template switch
+                {
+                    ServerType.Study => _serverFactory.StudyServer(command.Title, command.Image),
+                    ServerType.Gaming => _serverFactory.GamingServer(command.Title, command.Image),
+                    ServerType.Default or _ => _serverFactory.DefaultServer(command.Title, command.Image)
+                };
 
             await _serverProfileRepository.AddAsync(owner, cancellationToken);
             await Context.Servers.AddAsync(server, cancellationToken);
-            await Context.Channels.AddAsync(welcomeChannel, cancellationToken);
+            await Context.Channels.AddManyAsync(channels, cancellationToken);
 
             return server;
         }

--- a/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
+++ b/Application/Servers/Commands/CreateServer/CreateServerCommandHandler.cs
@@ -14,14 +14,14 @@ namespace Sparkle.Application.Servers.Commands.CreateServer
         {
             Context.SetToken(cancellationToken);
 
-            ServerType template = command.Template ?? ServerType.Default;
+            ServerTemplates template = command.Template ?? ServerTemplates.Default;
 
             (Server server, ServerProfile owner, List<Channel> channels) =
                 template switch
                 {
-                    ServerType.Study => _serverFactory.StudyServer(command.Title, command.Image),
-                    ServerType.Gaming => _serverFactory.GamingServer(command.Title, command.Image),
-                    ServerType.Default or _ => _serverFactory.DefaultServer(command.Title, command.Image)
+                    ServerTemplates.Study => _serverFactory.StudyServer(command.Title, command.Image),
+                    ServerTemplates.Gaming => _serverFactory.GamingServer(command.Title, command.Image),
+                    ServerTemplates.Default or _ => _serverFactory.DefaultServer(command.Title, command.Image)
                 };
 
             await _serverProfileRepository.AddAsync(owner, cancellationToken);

--- a/WebApi/Controllers/ServersController.cs
+++ b/WebApi/Controllers/ServersController.cs
@@ -104,6 +104,8 @@ namespace Sparkle.WebApi.Controllers
         {
             Server server = await Mediator.Send(command);
 
+            await Mediator.Send(new NotifyServerUpdatedQuery { ServerId = server.Id });
+
             return CreatedAtAction(nameof(GetServerDetails), new { serverId = server.Id }, server.Id);
         }
 


### PR DESCRIPTION
### Problem
Previously, servers were created without any predefined channels, which might not be optimal for users starting with a blank server. Additionally, there was a need to introduce server templates for specific use cases.

### Sulution
The task at hand is to make it so that servers are created with a welcome channel by default (closes #98). This enhances the user experience, especially for those who are new to the platform.

Additionally, we are introducing two new server templates: "Gaming" and "Study." To use these templates, clients should add a `template` field to the `CreateServerCommand` (closes #97):

- Set `template` to 1 to create a **Gaming** server.
- Set `template` to 2 to create a **Study** server.
- Set `template` to 3 to create a **School** server.
- Set `template` to 4 to create a **Friends** server.
- Set `template` to 0 or leave it as null to create a **Default** server.

These changes will provide more flexibility to users when creating servers and improve the default server setup. Please proceed with this task, and feel free to provide any feedback.
