### PR TITLE
Blocking

### DIFF
--- a/Application/Chats/PersonalChats/Commands/CreateChat/CreatePersonalChatCommandHandler.cs
+++ b/Application/Chats/PersonalChats/Commands/CreateChat/CreatePersonalChatCommandHandler.cs
@@ -27,8 +27,17 @@ namespace Sparkle.Application.Chats.PersonalChats.Commands.CreateChat
             Relationship? relationship = await _relationshipRepository
                 .FindOrDefaultAsync((command.UserId, UserId), cancellationToken);
 
-            if (relationship is not null && relationship.PersonalChatId != null)
+            if (relationship != null && relationship.PersonalChatId != null)
                 throw new InvalidOperationException("Chat already exists");
+
+            if (relationship == RelationshipTypes.Blocked)
+            {
+                string exceptionMessage = relationship.Active == UserId ?
+                    "You block this user" :
+                    "You blocked by this user";
+
+                throw new InvalidOperationException(exceptionMessage);
+            }
 
             PersonalChat chat = new()
             {

--- a/Application/Common/Interfaces/Repositories/IRelationshipRepository.cs
+++ b/Application/Common/Interfaces/Repositories/IRelationshipRepository.cs
@@ -7,6 +7,8 @@ namespace Sparkle.Application.Common.Interfaces.Repositories
     /// </summary>
     public interface IRelationshipRepository : IRepository<Relationship, (Guid Active, Guid Passive)>
     {
+        Task<Relationship> FindByChatIdAsync(string chatId, CancellationToken cancellationToken);
+
         /// <summary>
         /// Updates the relationship with ability to swap keys .
         /// </summary>

--- a/Application/Messages/Commands/AddMessage/AddMessageCommandHandler.cs
+++ b/Application/Messages/Commands/AddMessage/AddMessageCommandHandler.cs
@@ -10,22 +10,40 @@ namespace Sparkle.Application.Messages.Commands.AddMessage
 {
     public class AddMessageCommandHandler : RequestHandlerBase, IRequestHandler<AddMessageCommand, MessageDto>
     {
-        private readonly Common.Interfaces.Repositories.IUserProfileRepository _userProfileRepository;
+        private readonly IUserProfileRepository _userProfileRepository;
         private readonly IServerProfileRepository _serverProfileRepository;
+        private readonly IRelationshipRepository _relationshipRepository;
 
         public async Task<MessageDto> Handle(AddMessageCommand request, CancellationToken cancellationToken)
         {
             Context.SetToken(cancellationToken);
 
             Chat chat = await Context.Chats.FindAsync(request.ChatId, cancellationToken);
-            UserProfile profile;
+            UserProfile? profile = null;
             if (chat is Channel channel)
             {
-                profile = await _serverProfileRepository.FindUserProfileOnServerAsync(channel.ServerId, UserId, cancellationToken)
-                    ?? throw new EntityNotFoundException(message: $"User {UserId} profile not found in server {channel.ServerId}", "");
+                profile = await _serverProfileRepository.
+                    FindUserProfileOnServerAsync(channel.ServerId, UserId, cancellationToken)
+                    ?? throw new EntityNotFoundException(message: $"User {UserId} profile not found" +
+                    $" in server {channel.ServerId}", "");
             }
-            else
-                profile = await _userProfileRepository.FindByChatIdAndUserIdAsync(chat.Id, UserId, cancellationToken);
+            else if (chat is PersonalChat personalChat)
+            {
+                Relationship relationship = await _relationshipRepository
+                    .FindByChatIdAsync(chat.Id, cancellationToken);
+
+                if (relationship == RelationshipTypes.Blocked)
+                {
+                    string exceptionMessage = relationship.Active == UserId ?
+                    "You block this user" :
+                    "You blocked by this user";
+
+                    throw new InvalidOperationException(exceptionMessage);
+                }
+            }
+
+            profile ??= await _userProfileRepository
+                .FindByChatIdAndUserIdAsync(chat.Id, UserId, cancellationToken);
 
             List<Attachment> attachments = new();
 
@@ -71,11 +89,16 @@ namespace Sparkle.Application.Messages.Commands.AddMessage
             return dto;
         }
 
-        public AddMessageCommandHandler(IAppDbContext context, IAuthorizedUserProvider userProvider, IMapper mapper, Common.Interfaces.Repositories.IUserProfileRepository userProfileRepository, IServerProfileRepository serverProfileRepository) :
-            base(context, userProvider, mapper)
+        public AddMessageCommandHandler(IAppDbContext context,
+            IAuthorizedUserProvider userProvider,
+            IMapper mapper,
+            IUserProfileRepository userProfileRepository,
+            IServerProfileRepository serverProfileRepository,
+            IRelationshipRepository relationshipRepository) : base(context, userProvider, mapper)
         {
             _userProfileRepository = userProfileRepository;
             _serverProfileRepository = serverProfileRepository;
+            _relationshipRepository = relationshipRepository;
         }
     }
 }

--- a/Application/Users/Relationships/Commands/BlockUser/BlockUserCommand.cs
+++ b/Application/Users/Relationships/Commands/BlockUser/BlockUserCommand.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using Sparkle.Application.Models;
+
+namespace Sparkle.Application.Users.Relationships.Commands
+{
+    public record BlockUserCommand(Guid UserId) : IRequest<Relationship>
+    {
+    }
+}

--- a/Application/Users/Relationships/Commands/BlockUser/BlockUserCommandHandler.cs
+++ b/Application/Users/Relationships/Commands/BlockUser/BlockUserCommandHandler.cs
@@ -1,0 +1,50 @@
+﻿using MediatR;
+using Sparkle.Application.Common.Interfaces;
+using Sparkle.Application.Common.Interfaces.Repositories;
+using Sparkle.Application.Models;
+
+namespace Sparkle.Application.Users.Relationships.Commands
+{
+    public class BlockUserCommandHandler : RequestHandlerBase, IRequestHandler<BlockUserCommand, Relationship>
+    {
+        private readonly IRelationshipRepository _relationshipRepository;
+
+        public BlockUserCommandHandler(IAppDbContext context,
+            IAuthorizedUserProvider userProvider,
+            IRelationshipRepository relationshipRepository) : base(context, userProvider)
+        {
+            _relationshipRepository = relationshipRepository;
+        }
+
+        public async Task<Relationship> Handle(BlockUserCommand command, CancellationToken cancellationToken)
+        {
+            Relationship? relationship = await _relationshipRepository
+                .FindOrDefaultAsync((UserId, command.UserId), cancellationToken);
+
+            if (relationship is not null)
+            {
+                if (relationship == RelationshipTypes.Blocked)
+                    throw new InvalidOperationException("You already block this user");
+
+                relationship.Active = UserId;
+                relationship.Passive = command.UserId;
+                relationship.RelationshipType = RelationshipTypes.Blocked;
+
+                relationship = await _relationshipRepository.UpdateWithKeysAsync(relationship, cancellationToken);
+            }
+            else
+            {
+                relationship = new()
+                {
+                    Active = UserId,
+                    Passive = command.UserId,
+                    RelationshipType = RelationshipTypes.Blocked
+                };
+
+                await _relationshipRepository.AddAsync(relationship, cancellationToken);
+            }
+
+            return relationship;
+        }
+    }
+}

--- a/Application/Users/Relationships/Commands/BlockUser/BlockUserCommandValidator.cs
+++ b/Application/Users/Relationships/Commands/BlockUser/BlockUserCommandValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+
+namespace Sparkle.Application.Users.Relationships.Commands
+{
+    public class BlockUserCommandValidator : AbstractValidator<BlockUserCommand>
+    {
+        public BlockUserCommandValidator()
+        {
+            RuleFor(c => c.UserId).NotEmpty();
+        }
+    }
+}

--- a/Application/Users/Relationships/Commands/UnblockUser/UnblockUserCommand.cs
+++ b/Application/Users/Relationships/Commands/UnblockUser/UnblockUserCommand.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using Sparkle.Application.Models;
+
+namespace Sparkle.Application.Users.Relationships.Commands
+{
+    public record UnblockUserCommand(Guid UserId) : IRequest<Relationship>
+    {
+    }
+}

--- a/Application/Users/Relationships/Commands/UnblockUser/UnblockUserCommandHandler.cs
+++ b/Application/Users/Relationships/Commands/UnblockUser/UnblockUserCommandHandler.cs
@@ -1,0 +1,40 @@
+﻿using MediatR;
+using Sparkle.Application.Common.Interfaces;
+using Sparkle.Application.Common.Interfaces.Repositories;
+using Sparkle.Application.Models;
+
+namespace Sparkle.Application.Users.Relationships.Commands
+{
+    public class UnblockUserCommandHandler : RequestHandlerBase, IRequestHandler<UnblockUserCommand, Relationship>
+    {
+        private readonly IRelationshipRepository _relationshipRepository;
+
+        public UnblockUserCommandHandler(IAppDbContext context,
+            IAuthorizedUserProvider userProvider,
+            IRelationshipRepository relationshipRepository) : base(context, userProvider)
+        {
+            _relationshipRepository = relationshipRepository;
+        }
+
+        public async Task<Relationship> Handle(UnblockUserCommand command, CancellationToken cancellationToken)
+        {
+            Relationship relationship = await _relationshipRepository
+                .FindAsync((UserId, command.UserId), cancellationToken);
+
+            if (relationship != RelationshipTypes.Blocked || relationship.Active != UserId)
+                throw new InvalidOperationException("You cand unblock this user");
+
+            if (relationship.PersonalChatId is not null)
+            {
+                relationship.RelationshipType = RelationshipTypes.Acquaintance;
+                await _relationshipRepository.UpdateAsync(relationship, cancellationToken);
+            }
+            else
+            {
+                await _relationshipRepository.DeleteAsync(relationship, cancellationToken);
+            }
+
+            return relationship;
+        }
+    }
+}

--- a/Application/Users/Relationships/Commands/UnblockUser/UnblockUserCommandValidator.cs
+++ b/Application/Users/Relationships/Commands/UnblockUser/UnblockUserCommandValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+
+namespace Sparkle.Application.Users.Relationships.Commands
+{
+    public class UnblockUserCommandValidator : AbstractValidator<UnblockUserCommand>
+    {
+        public UnblockUserCommandValidator()
+        {
+            RuleFor(c => c.UserId).NotEmpty();
+        }
+    }
+}

--- a/DataAccess/Repositories/RelationshipRepository.cs
+++ b/DataAccess/Repositories/RelationshipRepository.cs
@@ -94,5 +94,8 @@ namespace Sparkle.DataAccess.Repositories
 
             return relationship;
         }
+
+        public async Task<Relationship> FindByChatIdAsync(string chatId, CancellationToken cancellationToken)
+            => await DbSet.SingleAsync(relationship => relationship.PersonalChatId == chatId, cancellationToken);
     }
 }

--- a/WebApi/Controllers/UsersController.cs
+++ b/WebApi/Controllers/UsersController.cs
@@ -212,5 +212,15 @@ namespace Sparkle.WebApi.Controllers
             await Mediator.Send(new NotifyRelationshipDelatedQuery() { Relationship = relationship });
             return NoContent();
         }
+
+        [HttpPost("block")]
+        public async Task<ActionResult> BlockUser(Guid userId)
+        {
+            BlockUserCommand command = new(userId);
+            Relationship relationship = await Mediator.Send(command);
+
+            await Mediator.Send(new NotifyRelationshipUpdatedQuery() { Relationship = relationship });
+            return NoContent();
+        }
     }
 }

--- a/WebApi/Controllers/UsersController.cs
+++ b/WebApi/Controllers/UsersController.cs
@@ -222,5 +222,15 @@ namespace Sparkle.WebApi.Controllers
             await Mediator.Send(new NotifyRelationshipUpdatedQuery() { Relationship = relationship });
             return NoContent();
         }
+
+        [HttpDelete("block")]
+        public async Task<ActionResult> UnblockUser(Guid userId)
+        {
+            UnblockUserCommand command = new(userId);
+            Relationship relationship = await Mediator.Send(command);
+
+            await Mediator.Send(new NotifyRelationshipDelatedQuery() { Relationship = relationship });
+            return NoContent();
+        }
     }
 }


### PR DESCRIPTION
### Changes

- Created `POST users/block` endpoint, which allows users to block other users.
- Created `DELETE users/block` endpoint, which enables users to unblock other users.
Closes #143 
### Important

- When one user unblocks another user, they will become `Acquaintance` even if they were previously `Friends`.
- If users are blocked, they are restricted from:
  - Sending messages to each other.
  - Creating `PersonalChat` with each other.
